### PR TITLE
Debounce Dynaframe image requests

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -5,3 +5,6 @@ dynaframe_hostname="dfmarquee"
 
 # Root path/playlist of fallback images when the requested image can't be found
 fallback_playlist="/home/pi/Pictures/Default/"
+
+# Time in seconds to wait for the UI to become idle before sending a request
+idle_wait=0.3

--- a/game-selected/dynamic_marquee.sh
+++ b/game-selected/dynamic_marquee.sh
@@ -6,6 +6,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # Source config.sh from one directory up
 source "$script_dir/../config.sh"
 
+# File used to debounce rapid-fire requests
+debounce_file=/tmp/dynaframe_last_request
+
 # Set logfile location and filename
 logfile=/tmp/scriptlog.txt
 
@@ -25,6 +28,16 @@ log_error() {
     
     # Log the error message with timestamp
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$logfile"
+}
+
+debounced_send_command() {
+    local filepath=$1
+    printf '%s' "$filepath" > "$debounce_file"
+    sleep "$idle_wait"
+    local current=$(cat "$debounce_file" 2>/dev/null)
+    if [ "$current" = "$filepath" ]; then
+        send_command "$filepath"
+    fi
 }
 
 send_command() {
@@ -75,4 +88,4 @@ fi
 # send_command "AutomaticMode" "FALSE"
 
 # Send command to show the logo of the system selected
-send_command "${marquee_path}${systemname}/images/${romname}-marquee.${extension}"
+debounced_send_command "${marquee_path}${systemname}/images/${romname}-marquee.${extension}"

--- a/system-selected/dynamic_marquee.sh
+++ b/system-selected/dynamic_marquee.sh
@@ -6,6 +6,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # Source config.sh from one directory up
 source "$script_dir/../config.sh"
 
+# File used to debounce rapid-fire requests
+debounce_file=/tmp/dynaframe_last_request
+
 # Set logfile location and filename
 logfile=/tmp/scriptlog.txt
 
@@ -25,6 +28,16 @@ log_error() {
     
     # Log the error message with timestamp
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$logfile"
+}
+
+debounced_send_command() {
+    local filepath=$1
+    printf '%s' "$filepath" > "$debounce_file"
+    sleep "$idle_wait"
+    local current=$(cat "$debounce_file" 2>/dev/null)
+    if [ "$current" = "$filepath" ]; then
+        send_command "$filepath"
+    fi
 }
 
 send_command() {
@@ -68,4 +81,4 @@ romname=$(basename "${2%.*}")
 # send_command "AutomaticMode" "FALSE"
 
 # Tells Dynaframe to show the logo of the system you have selected in the Batocera UI
-send_command "${logo_path}${systemname}.png"
+debounced_send_command "${logo_path}${systemname}.png"


### PR DESCRIPTION
## Summary
- introduce `idle_wait` configuration for delaying Dynaframe requests
- debounced `dynamic_marquee.sh` scripts so only the most recent request is sent

## Testing
- `bash -n config.sh game-selected/dynamic_marquee.sh system-selected/dynamic_marquee.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b985dd48248332b270b6dec0ad8ff9